### PR TITLE
Fix for Github API rate limiting

### DIFF
--- a/workflow-templates/localgov-drupal-ci.yml
+++ b/workflow-templates/localgov-drupal-ci.yml
@@ -22,7 +22,9 @@ jobs:
         run: composer create-project --stability dev localgovdrupal/localgov-project html
 
       - name: Setup package source for the test target
-        run: composer --working-dir=html config repositories.1 vcs git@github.com:${{ github.repository }}.git
+        run: |
+          composer --working-dir=html config repositories.1 vcs git@github.com:${{ github.repository }}.git
+          composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Extract Git branch name outside of a pull request
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Composer is hitting Github's API rate limits during [test runs](https://github.com/localgovdrupal/localgov_theme/runs/1214208506?check_suite_focus=true#step:7:13).  To avoid this, composer has to use the Github authentication token.

@see https://getcomposer.org/doc/articles/troubleshooting.md#api-rate-limit-and-oauth-tokens
@see https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow